### PR TITLE
Add task for flashing project

### DIFF
--- a/templates/.vscode/tasks.json
+++ b/templates/.vscode/tasks.json
@@ -34,6 +34,22 @@
                 "cwd": "${workspaceFolder}"
             },
             "problemMatcher": []
+        },
+        {
+            "type": "shell",
+            "label": "Flash project",
+            "command": "STM32_Programmer_CLI",
+            "args": [
+                "--connect",
+                "port=swd",
+                "--download",
+                "${command:cmake.launchTargetPath}",
+                "-hardRst"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": []
         }
     ]
 }


### PR DESCRIPTION
The task for flashing the project to the board (https://github.com/MaJerle/stm32-cube-cmake-vscode/pull/4) has been lost with commit dbe349058d3454afad2b96d4f535c1449db9e1fd.

I verified that the tasks works good even after the changes made to support `cmake-presets`, so I assume it was removed accidentally.